### PR TITLE
How to Demonstrate Bedework Calendar

### DIFF
--- a/docs/admin/training.md
+++ b/docs/admin/training.md
@@ -109,3 +109,15 @@ https://metronashville.sharepoint.com/:l:/s/NPLWebDevelopment/FHX2jii9-xRMgZYJPw
 1. Prepare orientation Notes
 
 ## Perform Orientation
+
+In demonstration, cover how to
+
+### Public Calendar
+
+1. Get to public calendar.
+1. Use search and limiters to narrow event results; clear limiters.
+1. Scroll the list for future events.
+1. Ongoing event area.
+1. `Manage Events` link to access login area.
+
+###

--- a/docs/admin/training.md
+++ b/docs/admin/training.md
@@ -120,4 +120,28 @@ In demonstration, cover how to
 1. Ongoing event area.
 1. `Manage Events` link to access login area.
 
-###
+### Add Event
+
+1. Use tabbed navigation to access areas.
+1. Use `Add event` screen to enter new events.
+1. Access the images library for copying exisiting image paths. 
+1. Use Browse computer to upload a bespoke image.
+1. Reference WCAG 2.1 guidelines for making accessibile images.
+1. Use Bedework local image library to add Alt Text.
+
+### Approval Queue
+
+1. Browse to Approal Queue to see all pending events.
+1. Delete events that fall on closed dates.
+1. Edit individual instances for special occasions.
+
+### Manage Events
+
+1. Search all published events. 
+1. Use `copy event` to generate a duplicate stub from which to create a similar event.
+
+### Local Workflows
+
+1. Make updates to events in approval queue.
+1. Contact Shared Systems for published events.
+1. (Manager) uses `cancel event`, when events are canceled last-minute.


### PR DESCRIPTION
# Background

Need loose outline for demonstrating crucial Bedework enterprise calendar features. Function and workflows may change. However, these concepts should be evergreen for documentation. 

This outline follows steps for arranging the training in the public library.

# Test

Review notes under **Perform Orientation**. Determine if this outline provides enough for one familiar with Bedework to conduct a demonstration of the major features and local usage.
