### PR TITLE
Repairing Links to catalog

### DIFF
--- a/docs/add-events/description.md
+++ b/docs/add-events/description.md
@@ -149,7 +149,7 @@ Use “teens” language for all Teen events at Main Library
 
 Put this language at the end of the event description
 
-    Visit library.nashville.org/universe to see all NPL events you can stream from home.
+    Visit library.nashville.gov/universe to see all NPL events you can stream from home.
 
 ### Seed Exchange
 
@@ -157,4 +157,4 @@ Append this Seed Exchange pitch to all gardening events.
 
     This program is brought to you by Nashville Public Library Seed Exchange. Borrow seeds, grow plants, return seeds. Seeds are available for check out at select branches. For more information, go to Seed Exchange website. 
     
-Add to _Event URL_: https://library.nashville.org/event/seed-exchange
+Add to _Event URL_: https://library.nashville.gov/event/seed-exchange

--- a/docs/admin/training.md
+++ b/docs/admin/training.md
@@ -76,11 +76,11 @@ Static Web Page Checkup
 Please check your location’s information on the following webpages. Email [First Last] any changes to these static listings.
 
 - Story Time
-   - https://library.nashville.org/events/story-time
+   - https://library.nashville.gov/events/story-time
 - Book Clubs
-   - https://library.nashville.org/events/book-clubs
+   - https://library.nashville.gov/events/book-clubs
 - Studio NPL
-   - https://library.nashville.org/events/studio-npl
+   - https://library.nashville.gov/events/studio-npl
 
 Bedework Orientation
 

--- a/docs/admin/troubleshooting.md
+++ b/docs/admin/troubleshooting.md
@@ -37,19 +37,19 @@ If an event is not visible in either the public client or the admin client, we n
 Display of events is happy (calendar is working), but the feed might be unhappy.
 
 1. Look and see if widgets are busted EVERYWHERE or just in specific sites / instances (check all npl site pages, salon, nashville reads, digital signs).
-    1. [https://library.nashville.org/](https://library.nashville.org/)
-    1. [https://library.nashville.org/event/be-well-npl](https://library.nashville.org/event/be-well-npl)
-    1. [https://library.nashville.org/locations/main-library](https://library.nashville.org/locations/main-library)
-    1. [https://library.nashville.org/income-tax-help](https://library.nashville.org/income-tax-help)
-    1. [http://nashvillepubliclibrary.org/nashvillereads/events/](http://nashvillepubliclibrary.org/nashvillereads/events/)
-    1. [http://nashvillepubliclibrary.org/salonat615/](http://nashvillepubliclibrary.org/salonat615/)
+    1. [https://library.nashville.gov/](https://library.nashville.org/)
+    1. [https://library.nashville.gov/event/be-well-npl](https://library.nashville.org/event/be-well-npl)
+    1. [https://library.nashville.gov/locations/main-library](https://library.nashville.org/locations/main-library)
+    1. [https://library.nashville.gov/income-tax-help](https://library.nashville.org/income-tax-help)
+    1. [http://nashvillepubliclibrary.gov/nashvillereads/events/](http://nashvillepubliclibrary.org/nashvillereads/events/)
+    1. [http://nashvillepubliclibrary.gov/salonat615/](http://nashvillepubliclibrary.org/salonat615/)
     1. With image signs:
-        1. http://firesign.library.nashville.org/MN_moviesAtMain.htm
+        1. http://firesign.library.nashville.gov/MN_moviesAtMain.htm
         1. http://firesign.library.nashville.org/MN_courtyardconcerts.html
     1. No image signs:
-        1. [http://firesign.library.nashville.org/BL_NovelConversations.html](http://firesign.library.nashville.org/BL_NovelConversations.html)
-        1. [http://firesign.library.nashville.org/GO_PageTurners.html](http://firesign.library.nashville.org/GO_PageTurners.html)
-        1. [http://firesign.library.nashville.org/MN_killerthrillers.html](http://firesign.library.nashville.org/MN_killerthrillers.html)
+        1. [http://firesign.library.nashville.gov/BL_NovelConversations.html](http://firesign.library.nashville.gov/BL_NovelConversations.html)
+        1. [http://firesign.library.nashville.gov/GO_PageTurners.html](http://firesign.library.nashville.org/GO_PageTurners.html)
+        1. [http://firesign.library.nashville.gov/MN_killerthrillers.html](http://firesign.library.nashville.org/MN_killerthrillers.html)
     1. Restart Bedework.
     1. Report to Bedework vendor, if restart doesn’t fix widgets. Report where widgets are malfunctioning.
 
@@ -87,7 +87,7 @@ Events stuck in approval queue that don’t really exist.
     1. Service Temporarily Unavailable
 
 > The server is temporarily unable to service your request due to maintenance downtime or capacity problems. Please try again later.`
-`Apache/2.2.3 (Red Hat) Server at events.library.nashville.org Port 80`
+`Apache/2.2.3 (Red Hat) Server at events.library.nashville.gov Port 80`
 
 Info: Bedework Vendor had a backup file saved somewhere and Bedework was trying to load two files at once. For some reason it started causing problems one day. He removed the backup file and the calendar was fine.
 

--- a/docs/admin/troubleshooting.md
+++ b/docs/admin/troubleshooting.md
@@ -87,7 +87,7 @@ Events stuck in approval queue that don’t really exist.
     1. Service Temporarily Unavailable
 
 > The server is temporarily unable to service your request due to maintenance downtime or capacity problems. Please try again later.`
-`Apache/2.2.3 (Red Hat) Server at events.library.nashville.gov Port 80`
+`Apache/2.2.3 (Red Hat) Server at events.library.nashville.org Port 80`
 
 Info: Bedework Vendor had a backup file saved somewhere and Bedework was trying to load two files at once. For some reason it started causing problems one day. He removed the backup file and the calendar was fine.
 

--- a/docs/image-library/series-logos.md
+++ b/docs/image-library/series-logos.md
@@ -124,7 +124,7 @@ Three bingo cards in blue green and red.
 Alt Text
 
 ```text
-Graphic reads celebrate black history month with us. library.nashville.org/bhm. White letters against a blue and red background.
+Graphic reads celebrate black history month with us. library.nashville.gov/bhm. White letters against a blue and red background.
 ```
 
 ## Black Female Authors Book Club

--- a/docs/image-library/topic-logos.md
+++ b/docs/image-library/topic-logos.md
@@ -107,7 +107,7 @@ Join us for book club words next to a stack of books.
 Alt Text
 
 ```text
-Words book sale atop a row of books. book sale logo has url for npl.org slash friends. reads proceeds benefit nashville public library.
+Words book sale atop a row of books. book sale logo has url for npl.gov slash friends. reads proceeds benefit nashville public library.
 ```
 
 ## Caffeinated Book Club

--- a/docs/orientation/get-to-bedework.md
+++ b/docs/orientation/get-to-bedework.md
@@ -5,6 +5,6 @@ sidebar_position: 1
 
 # How to Get to Bedework
 - Go directly to the calendar by typing the URL: [https://events.library.nashville.org](https://events.library.nashville.org)
-- Go to the library website (https://library.nashville.org), mouse over Events in the main menu, and select Calendar in the sub-menu:
+- Go to the library website (https://library.nashville.gov), mouse over Events in the main menu, and select Calendar in the sub-menu:
 
 ![mega-menu](../img/scrn-mega-menu-calendar.jpg "mega menu")

--- a/docs/using-images/finding-images.md
+++ b/docs/using-images/finding-images.md
@@ -11,7 +11,7 @@ sidebar_position: 2
   - Add with URL.
   - Logo images
   - Grab the URL from the spreadsheet to use the image in a calendar listing.
-- [Library Catalog](http://catalog.library.nashville.org)
+- [Library Catalog](http://catalog.library.nashville.gov)
   - Add with URL.
   - The library licenses the cover images used in the catalog from Syndetics. We pay for the rights to use those images. Copy link address and paste in the image field for your event.
 - [Nashville Public Library on Flickr](http://www.flickr.com/photos/nashvillepubliclibrary)

--- a/docs/using-images/get-to-bedework.md
+++ b/docs/using-images/get-to-bedework.md
@@ -4,7 +4,7 @@ sidebar_position: 1
 ---
 
 # How to Get to Bedework
-- Go directly to the calendar by typing the URL: [https://events.library.nashville.gov](https://events.library.nashville.gov)
+- Go directly to the calendar by typing the URL: [https://events.library.nashville.org](https://events.library.nashville.org)
 - Go to the library website (https://library.nashville.gov), mouse over Events in the main menu, and select Calendar in the sub-menu:
 
 ![mega-menu](../img/scrn-mega-menu-calendar.jpg "mega menu")

--- a/docs/using-images/get-to-bedework.md
+++ b/docs/using-images/get-to-bedework.md
@@ -1,0 +1,10 @@
+---
+title: How to Get to Bedework
+sidebar_position: 1
+---
+
+# How to Get to Bedework
+- Go directly to the calendar by typing the URL: [https://events.library.nashville.gov](https://events.library.nashville.gov)
+- Go to the library website (https://library.nashville.gov), mouse over Events in the main menu, and select Calendar in the sub-menu:
+
+![mega-menu](../img/scrn-mega-menu-calendar.jpg "mega menu")


### PR DESCRIPTION
# Background

Catalog is now catalog.library.nashville.gov. All links should reflect this.

Bedework is not at .gov. Links to Bedework should remain dot org, for now.