### PR TITLE
mixing up instructions for admins and users for cancel and delte

### DIFF
--- a/docs/change-events/cancel.md
+++ b/docs/change-events/cancel.md
@@ -3,29 +3,29 @@ title: Cancel or Reschedule
 sidebar_position: 1
 ---
 
+# For subummitters
+
 ## Mark canceled
 
-- **Canceled**: When the event is canceled, and the event is less than five days away, mark the event canceled. If event is more than five days out, delete event entirely.
+- When the event is canceled, and the event is less than five days away, mark the event canceled. If event is more than five days out, delete event entirely.
+  - Go to event detail. Under Status, select “canceled button. 
+  - Or, from Manage Events screen, use the `cancel event` button.
 
-- Go to event detail. Under Status, select “canceled button. 
-- Or, from Manage Events screen, use the `cancel event` button.
+## Delete or reschedule
 
-## Delete or Reschedule
+Once an event is published to the publicly-visitble calendar, submitters are no longer able to edit the event.  For these edits, email Shared Systems. 
 
-Once an event is published to the publicly-visitble calendar, most users are no longer able to edit the event.  For these edits, email Shared Systems. 
+# For approvers
 
 - **Time change only**: When a time changes, but the date is the same, update the existing event listing with new time.
 - **Date change only**: When the date changes, but the time is the same, update the existing event listing with new date.
 - **Date change (or date/time both change)**: When an event moves to a different date and time. Or, if multiple details change. Add a new entry in the Approval Queue, to verify all new details. Request Shared Systems delete the original published event, then publish the replacement entry. 
 - **Room change**: When an event moves from in-person to online and date/time is the same, update the existing event listing to add virtual event details, so patrons can connect. Essentially, the “room” changed from Inglewood to Online. Include “online" somewhere in the title.
 - **Duplicate entries** - If an event listing is a duplicate, delete the extra instance.
-- **Holidays / Closed Days**
+- **Holidays / closed day(s)**
   - Event falls during a period library is closed.
   - Approvers should delete all event listings that fall on holidays / closed days before approving.
-
-### Extended closure
-
-During the period when we are _not_ offering any in-person events, for a period longer than two weeks.
-
- - Delete in-person events from Bedework for the affected period.
- - Add any replacement events at other sites as new events. 
+- **Extended closure**
+  - During the period when we are _not_ offering any in-person events, for a period longer than two weeks.
+  - Delete in-person events from Bedework for the affected period.
+  - Add any replacement events at other sites as new events. 

--- a/docs/change-events/cancel.md
+++ b/docs/change-events/cancel.md
@@ -7,13 +7,13 @@ sidebar_position: 1
 
 ## Mark canceled
 
-- When the event is canceled, and the event is less than five days away, mark the event canceled. If event is more than five days out, delete event entirely.
+- When the event is canceled, and the event is less than five days away, mark the event canceled.   
   - Go to event detail. Under Status, select “canceled button. 
   - Or, from Manage Events screen, use the `cancel event` button.
 
 ## Delete or reschedule
 
-Once an event is published to the publicly-visitble calendar, submitters are no longer able to edit the event.  For these edits, email Shared Systems. 
+If event is more than five days out, delete event entirely. Once an event is published to the publicly-visitble calendar, submitters are no longer able to edit the event.  For these changes, email Shared Systems. 
 
 # For approvers
 

--- a/docs/change-events/cancel.md
+++ b/docs/change-events/cancel.md
@@ -3,35 +3,23 @@ title: Cancel or Reschedule
 sidebar_position: 1
 ---
 
-# Cancel or reschedule
-
-When event is less than five days out, mark events canceled. If event more than five days out, request Shared Systems delete the listing.
-
-## Cancel, edit or delete
-
-Once an event is published to the publicly-visitble calendar, most users are no longer able to edit the event. The Cancel function should only be used in the instances outlined below. All other edits require an email to Shared Systems.
+## Mark canceled
 
 - **Canceled**: When the event is canceled, and the event is less than five days away, mark the event canceled. If event is more than five days out, delete event entirely.
+
+- Go to event detail. Under Status, select “canceled button. 
+- Or, from Manage Events screen, use the `cancel event` button.
+
+## Delete or Reschedule
+
+Once an event is published to the publicly-visitble calendar, most users are no longer able to edit the event.  For these edits, email Shared Systems. 
+
 - **Time change only**: When a time changes, but the date is the same, update the existing event listing with new time.
 - **Date change only**: When the date changes, but the time is the same, update the existing event listing with new date.
 - **Date change (or date/time both change)**: When an event moves to a different date and time. Or, if multiple details change. Add a new entry in the Approval Queue, to verify all new details. Request Shared Systems delete the original published event, then publish the replacement entry. 
 - **Room change**: When an event moves from in-person to online and date/time is the same, update the existing event listing to add virtual event details, so patrons can connect. Essentially, the “room” changed from Inglewood to Online. Include “online" somewhere in the title.
-
-## Mark as canceled
-
-_Mark _canceled_ if:
-
-- Event was scheduled to occur in the next five days.
-
-### To cancel an event
-
-- Go to event detail. Select “canceled” radio button. 
-- Or, from Manage Events screen, use the `cancel event` button.
-
-## Delete
-
-- Duplicate entries - If an event listing is a duplicate, delete the extra instance.
-- Holidays / Closed Days
+- **Duplicate entries** - If an event listing is a duplicate, delete the extra instance.
+- **Holidays / Closed Days**
   - Event falls during a period library is closed.
   - Approvers should delete all event listings that fall on holidays / closed days before approving.
 

--- a/docs/change-events/cancel.md
+++ b/docs/change-events/cancel.md
@@ -3,7 +3,7 @@ title: Cancel or Reschedule
 sidebar_position: 1
 ---
 
-# For subummitters
+# For submitters
 
 ## Mark canceled
 


### PR DESCRIPTION
## Background

Assistant Director requested new tab for change events on documentation. 

## Proposed Solution.

I have combined instructions for general users, who just cancel events, and calendar administrators, who edit and delete events. It might be a total mess. Could you advise?